### PR TITLE
fixed failed build

### DIFF
--- a/integrations/jsr356/src/test/dependencies/ignoredVulnerableVersion.xml
+++ b/integrations/jsr356/src/test/dependencies/ignoredVulnerableVersion.xml
@@ -1,3 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: javax.websocket-api-1.1.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/javax\.websocket/javax\.websocket\-api@.*$</packageUrl>
+        <cpe>cpe:/a:java-websocket_project:java-websocket</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
One or more dependencies were identified with known vulnerabilities in HttpMaid - Integrations - JSR 356:
javax.websocket-api-1.1.jar (pkg:maven/javax.websocket/javax.websocket-api@1.1, cpe:2.3:a:java-websocket_project:java-websocket:1.1:*:*:*:*:*:*:*) : CVE-2020-11050

Fixes #...

## Summary of changes

- ...
- ...
